### PR TITLE
FEAT: Add CLI error handlers

### DIFF
--- a/cmds/commands_test.go
+++ b/cmds/commands_test.go
@@ -7,9 +7,11 @@ import (
 	"testing"
 
 	"github.com/jgfranco17/muxingbird/internal"
-	"github.com/jgfranco17/muxingbird/logging"
-	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+)
+
+const (
+	testValidSpecJsonFile string = "./resources/mock.json"
 )
 
 type mockService struct {
@@ -32,18 +34,11 @@ func newMockFactory(service *mockService) ServiceFactory {
 	}
 }
 
-func applyContextLogger(cmd *cobra.Command) {
-	logger := logging.NewLogger()
-	ctx := logging.ApplyToContext(context.Background(), logger)
-	cmd.SetContext(ctx)
-}
-
 func TestRunCommandSuccess(t *testing.T) {
 	mock := &mockService{}
 	factory := newMockFactory(mock)
 	cmd := CommandRun(factory)
-	applyContextLogger(cmd)
-	result := internal.ExecuteTestCommand(t, cmd, "./resources/mock.json")
+	result := internal.ExecuteTestCommand(t, cmd, testValidSpecJsonFile)
 	assert.NoError(t, result.Error, "Unexpected error while executing run command")
 }
 
@@ -51,7 +46,6 @@ func TestRunCommandFail_InvalidPath(t *testing.T) {
 	mock := &mockService{}
 	factory := newMockFactory(mock)
 	cmd := CommandRun(factory)
-	applyContextLogger(cmd)
 	result := internal.ExecuteTestCommand(t, cmd, "nonexistent")
 	assert.ErrorContains(t, result.Error, "no such file")
 }
@@ -62,7 +56,6 @@ func TestRunCommandFail_ServiceFactoryError(t *testing.T) {
 	}
 	factory := newMockFactory(mock)
 	cmd := CommandRun(factory)
-	applyContextLogger(cmd)
-	result := internal.ExecuteTestCommand(t, cmd, "./resources/mock.json")
+	result := internal.ExecuteTestCommand(t, cmd, testValidSpecJsonFile)
 	assert.ErrorContains(t, result.Error, "some mock error")
 }

--- a/cmds/injection.go
+++ b/cmds/injection.go
@@ -1,0 +1,26 @@
+package cmds
+
+import (
+	"context"
+	"io"
+
+	"github.com/jgfranco17/muxingbird/service"
+)
+
+type HttpService interface {
+	Run(ctx context.Context) error
+}
+
+type ShellExecutor interface {
+	Exec(ctx context.Context, name string, args string) (int, string, error)
+}
+
+type ServiceFactory func(ctx context.Context, r io.Reader, port int) (HttpService, error)
+
+func DefaultServiceFactory(ctx context.Context, r io.Reader, port int) (HttpService, error) {
+	srv, err := service.NewRestService(ctx, r, port)
+	if err != nil {
+		return nil, err
+	}
+	return srv, nil
+}

--- a/cmds/registry_test.go
+++ b/cmds/registry_test.go
@@ -32,7 +32,6 @@ func TestRegisterCommands_RegistersSubcommands(t *testing.T) {
 	reg.RegisterCommands([]*cobra.Command{mockCmd})
 
 	reg.rootCmd.Root().SetArgs([]string{"mock"})
-	err := reg.Execute()
-	require.NoError(t, err)
+	reg.Execute()
 	assert.True(t, called)
 }

--- a/errorx/error_handling.go
+++ b/errorx/error_handling.go
@@ -1,0 +1,61 @@
+package errorx
+
+import (
+	"errors"
+	"os"
+
+	"github.com/sirupsen/logrus"
+)
+
+// ErrorWithCode wraps an error with an associated exit code.
+type ErrorWithCode struct {
+	Err  error
+	Code ShellExitCode
+}
+
+// Error satisfies the error interface.
+func (e *ErrorWithCode) Error() string {
+	return e.Err.Error()
+}
+
+// Unwrap enables error unwrapping.
+func (e *ErrorWithCode) Unwrap() error {
+	return e.Err
+}
+
+// NewErrorWithCode returns a new ErrorWithCode.
+func NewErrorWithCode(err error, code ShellExitCode) error {
+	if err == nil {
+		return nil
+	}
+	return &ErrorWithCode{
+		Err:  err,
+		Code: code,
+	}
+}
+
+// ExtractCode returns the exit code associated with the error.
+// If the error does not implement ErrorWithCode, it returns
+// an generic exit error.
+func ExtractCode(err error) ShellExitCode {
+	var ew *ErrorWithCode
+	if errors.As(err, &ew) {
+		return ew.Code
+	}
+	return ExitGenericError
+}
+
+// HandleError prints the error message to stderr and exits
+// the program with the correct code.
+func HandleError(logger *logrus.Logger, err error) {
+	code := ExtractCode(err)
+	logger.Errorf("Muxingbird error: %v", err)
+	os.Exit(int(code))
+}
+
+func HandleRecovery(logger *logrus.Logger) {
+	if rec := recover(); rec != nil {
+		logger.Panicf("Panic recovered: %v", rec)
+		os.Exit(int(ExitPanic))
+	}
+}

--- a/errorx/exit_codes.go
+++ b/errorx/exit_codes.go
@@ -1,0 +1,27 @@
+package errorx
+
+// ShellExitCode represents a CLI process exit code.
+type ShellExitCode int
+
+const (
+	// ExitSuccess indicates successful execution.
+	ExitSuccess ShellExitCode = 0
+
+	// ExitGenericError is a non-specific error.
+	ExitGenericError ShellExitCode = 1
+
+	// ExitInvalidArgs is returned when CLI args are invalid.
+	ExitInvalidArgs ShellExitCode = 2
+
+	// ExitFileNotFound indicates a missing input file.
+	ExitFileNotFound ShellExitCode = 3
+
+	// ExitConfigError represents a config parsing error.
+	ExitConfigError ShellExitCode = 4
+
+	// ExitServerError represents internal server launch/exec errors.
+	ExitServerError ShellExitCode = 5
+
+	// ExitPanic indicates an unhandled panic or fatal error.
+	ExitPanic ShellExitCode = 100
+)

--- a/main.go
+++ b/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"github.com/jgfranco17/muxingbird/cmds"
-	"github.com/jgfranco17/muxingbird/logging"
 	"github.com/spf13/cobra"
 )
 
@@ -16,13 +15,10 @@ var (
 )
 
 func main() {
-	logger := logging.NewLogger()
 	command := cmds.NewCommandRegistry(projectName, projectDescription, version)
 	commandsList := []*cobra.Command{
 		cmds.CommandRun(cmds.DefaultServiceFactory),
 	}
 	command.RegisterCommands(commandsList)
-	if err := command.Execute(); err != nil {
-		logger.Fatalf("Muxingbird error: %v", err)
-	}
+	command.Execute()
 }


### PR DESCRIPTION
<!-- markdownlint-disable-file MD041 -->

# PULL REQUEST

## Description

Implement error handlers and wrappers in the CLI.

## Changes

<!-- List of changes -->

- Implement error codes and wrappers
- Catch end log errors at cmd root

## PR Checks

<!-- All points must be addressed before merge -->

- [ ] Release notes have been added
- [x] New code is covered by tests

## Testing

Go Tested

## Future Work

<!-- Optional -->
<!-- Add any future work plans that are not addressed by the PR but are raised by the PR -->

## Discussion Points

<!-- Optional -->
<!-- Points that need further discussion with the PR reviewers -->
