### PR TITLE
[FEAT] Implement init command

### DIFF
--- a/.github/releases/0.0.2.md
+++ b/.github/releases/0.0.2.md
@@ -1,0 +1,5 @@
+# Muxingbird v0.0.2
+
+## Changes
+
+- Implement `init` command to generate a new default config

--- a/cmds/commands.go
+++ b/cmds/commands.go
@@ -2,12 +2,14 @@ package cmds
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"time"
 
 	"github.com/jgfranco17/muxingbird/errorx"
 	"github.com/jgfranco17/muxingbird/logging"
+	"github.com/jgfranco17/muxingbird/service"
 	"github.com/spf13/cobra"
 )
 
@@ -50,5 +52,50 @@ func CommandRun(serviceFactory ServiceFactory) *cobra.Command {
 	}
 	cmd.Flags().DurationVarP(&activeDuration, "duration", "d", defaultMaxDuration, "Maximum duration to run server")
 	cmd.Flags().IntVarP(&port, "port", "p", defaultPort, "Port to run server on")
+	return cmd
+}
+
+// CommandInit creates a new Cobra command for initializing
+// a starter config with basic routes.
+func CommandInit() *cobra.Command {
+	var outputPath string
+	var force bool
+	cmd := &cobra.Command{
+		Use:   "init",
+		Short: "Generate a starter mock config file",
+		Long:  "Create a basic starter server definition file for the user to fill.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			logger := logging.FromContext(cmd.Context())
+			ctx, cancel := context.WithCancel(cmd.Context())
+			defer cancel()
+			if outputPath == "" {
+				if err := service.InitConfig(ctx, cmd.OutOrStdout()); err != nil {
+					return errorx.NewErrorWithCode(err, errorx.ExitGenericError)
+				}
+				return nil
+			}
+			if _, err := os.Stat(outputPath); err == nil && !force {
+				coreErr := fmt.Errorf("file %q already exists (use --force to overwrite)", outputPath)
+				return errorx.NewErrorWithCode(coreErr, errorx.ExitInvalidArgs)
+
+			}
+			file, err := os.Create(outputPath)
+			if err != nil {
+				return fmt.Errorf("failed to create file: %w", err)
+			}
+			defer func() {
+				if cerr := file.Close(); cerr != nil {
+					logger.Fatalf("Failed to close file: %v", cerr)
+				}
+			}()
+			if err := service.InitConfig(ctx, file); err != nil {
+				return errorx.NewErrorWithCode(err, errorx.ExitGenericError)
+			}
+			logger.Infof("Created new default config: %s", outputPath)
+			return nil
+		},
+	}
+	cmd.Flags().StringVarP(&outputPath, "output", "o", "", "Path to write config file (default: stdout)")
+	cmd.Flags().BoolVarP(&force, "force", "f", false, "Overwrite existing file if it exists")
 	return cmd
 }

--- a/cmds/commands_test.go
+++ b/cmds/commands_test.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"errors"
 	"io"
+	"path/filepath"
 	"testing"
 
 	"github.com/jgfranco17/muxingbird/internal"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -58,4 +60,27 @@ func TestRunCommandFail_ServiceFactoryError(t *testing.T) {
 	cmd := CommandRun(factory)
 	result := internal.ExecuteTestCommand(t, cmd, testValidSpecJsonFile)
 	assert.ErrorContains(t, result.Error, "some mock error")
+}
+
+func TestInitCommandSuccess_StdoutDefault(t *testing.T) {
+	result := internal.ExecuteTestCommand(t, CommandInit())
+	require.NoError(t, result.Error, "Unexpected error while running init command to stdout")
+}
+
+func TestInitCommandSuccess_CreateFile(t *testing.T) {
+	sampleInitOutputFile := "init-test.json"
+	mockOutputPath := filepath.Join(t.TempDir(), sampleInitOutputFile)
+	t.Run("new file", func(t *testing.T) {
+		resultToStdout := internal.ExecuteTestCommand(t, CommandInit(), "-o", mockOutputPath)
+		require.NoError(t, resultToStdout.Error, "Unexpected error while running init command with file")
+	})
+	t.Run("existing file", func(t *testing.T) {
+		resultToStdout := internal.ExecuteTestCommand(t, CommandInit(), "-o", mockOutputPath, "--force")
+		require.NoError(t, resultToStdout.Error, "Unexpected error while running init command with force")
+	})
+}
+
+func TestInitCommandFail_NoForceButFileExists(t *testing.T) {
+	result := internal.ExecuteTestCommand(t, CommandInit(), "-o", testValidSpecJsonFile)
+	require.Error(t, result.Error, "Wanted error, but got none")
 }

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ func main() {
 	command := cmds.NewCommandRegistry(projectName, projectDescription, version)
 	commandsList := []*cobra.Command{
 		cmds.CommandRun(cmds.DefaultServiceFactory),
+		cmds.CommandInit(),
 	}
 	command.RegisterCommands(commandsList)
 	command.Execute()

--- a/service/models.go
+++ b/service/models.go
@@ -1,6 +1,8 @@
 package service
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -30,4 +32,30 @@ func LoadFromContent(r io.Reader) (*ServerConfig, error) {
 		return nil, fmt.Errorf("invalid config format: %w", err)
 	}
 	return &server, nil
+}
+
+// InitConfig writes a sample mock server configuration to the provided writer.
+// The generated configuration includes a basic HTTP GET route with a sample
+// JSON response. This function is intended to help users bootstrap a valid
+// configuration file.
+func InitConfig(ctx context.Context, w io.Writer) error {
+	example := &ServerConfig{
+		Name: "new-mock-server",
+		Routes: []Route{
+			{
+				Method:   "GET",
+				Path:     "/hello",
+				Status:   200,
+				Response: MockResponseJson{"message": "Hello, world!"},
+			},
+		},
+	}
+	prettyPrintJson, err := json.MarshalIndent(example, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to encode sample config: %w", err)
+	}
+	if _, err = fmt.Fprintln(w, string(prettyPrintJson)); err != nil {
+		return fmt.Errorf("failed to write config: %w", err)
+	}
+	return nil
 }


### PR DESCRIPTION
<!-- markdownlint-disable-file MD041 -->

# PULL REQUEST

## Description

This PR introduces a new functionality of the CLI: the `init` command. This provides users with the ability to create a new config file, giving them a default JSON that they can spin up instantly.

## Changes

<!-- List of changes -->

- Implemented new `init` command
- Unit tests added

## PR Checks

<!-- All points must be addressed before merge -->

- [x] Release notes have been added for new features
- [x] Changes are covered by tests

## Testing

- Unit tested with Go Test
- Local execution

To test the changes locally:

1. Run the CLI with the `init` command and no arguments to generate the mock config to stdout.
2. Test the `init` command with the `--output` flag to specify a file path.
3. Test the `--force` flag by trying to overwrite an existing config file.
4. Check the logs to ensure that the correct messages are being logged and errors are handled as expected.

Example:

```bash
$ ./muxingbird init
$ ./muxingbird init --output config.json
$ ./muxingbird init --output config.json --force
```

## Future Work

- Implement additional validation for config content and structure.
- Add unit tests to further ensure coverage of error handling and file operations

## Discussion Points

- Consider whether we should improve how the logger handles fatal errors or panic scenarios.
- Would it be beneficial to implement a more advanced file locking mechanism to handle concurrency issues with file creation?
