### PR TITLE
FIX: Make config file path a flag arg

### DIFF
--- a/cmds/commands.go
+++ b/cmds/commands.go
@@ -20,18 +20,20 @@ const (
 
 // CommandRun creates a new Cobra command for running the HTTP service.
 func CommandRun(serviceFactory ServiceFactory) *cobra.Command {
+	var configFile string
 	var port int
 	var activeDuration time.Duration
+
 	cmd := &cobra.Command{
 		Use:   "run",
-		Args:  cobra.ExactArgs(1),
+		Args:  cobra.ExactArgs(0),
 		Short: "Run the server from the config",
 		Long:  "Spin up the HTTP service based on the definitions file",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			logger := logging.FromContext(cmd.Context())
 			ctx, cancel := context.WithTimeout(cmd.Context(), activeDuration)
 			defer cancel()
-			path, err := filepath.Abs(args[0])
+			path, err := filepath.Abs(configFile)
 			if err != nil {
 				return errorx.NewErrorWithCode(err, errorx.ExitInvalidArgs)
 			}
@@ -50,8 +52,11 @@ func CommandRun(serviceFactory ServiceFactory) *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
+
+	cmd.Flags().StringVarP(&configFile, "config-file", "f", service.ConfigFileName, "Service definition file")
 	cmd.Flags().DurationVarP(&activeDuration, "duration", "d", defaultMaxDuration, "Maximum duration to run server")
 	cmd.Flags().IntVarP(&port, "port", "p", defaultPort, "Port to run server on")
+
 	return cmd
 }
 

--- a/cmds/commands_test.go
+++ b/cmds/commands_test.go
@@ -40,7 +40,7 @@ func TestRunCommandSuccess(t *testing.T) {
 	mock := &mockService{}
 	factory := newMockFactory(mock)
 	cmd := CommandRun(factory)
-	result := internal.ExecuteTestCommand(t, cmd, testValidSpecJsonFile)
+	result := internal.ExecuteTestCommand(t, cmd, "-f", testValidSpecJsonFile)
 	assert.NoError(t, result.Error, "Unexpected error while executing run command")
 }
 
@@ -48,7 +48,7 @@ func TestRunCommandFail_InvalidPath(t *testing.T) {
 	mock := &mockService{}
 	factory := newMockFactory(mock)
 	cmd := CommandRun(factory)
-	result := internal.ExecuteTestCommand(t, cmd, "nonexistent")
+	result := internal.ExecuteTestCommand(t, cmd, "-f", "nonexistent")
 	assert.ErrorContains(t, result.Error, "no such file")
 }
 
@@ -58,7 +58,7 @@ func TestRunCommandFail_ServiceFactoryError(t *testing.T) {
 	}
 	factory := newMockFactory(mock)
 	cmd := CommandRun(factory)
-	result := internal.ExecuteTestCommand(t, cmd, testValidSpecJsonFile)
+	result := internal.ExecuteTestCommand(t, cmd, "-f", testValidSpecJsonFile)
 	assert.ErrorContains(t, result.Error, "some mock error")
 }
 

--- a/service/models.go
+++ b/service/models.go
@@ -9,6 +9,10 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+const (
+	ConfigFileName string = "muxingbird.yaml"
+)
+
 // ServerConfig represents a single HTTP server's configuration.
 type ServerConfig struct {
 	Name   string  `json:"name"`


### PR DESCRIPTION
<!-- markdownlint-disable-file MD041 -->

# PULL REQUEST

## Description

To simplify the user experience, we set a default name for the config file and look for that. Users can overwrite this via the `--config-file` / `-f` flag.

## Changes

<!-- List of changes -->

- Make config file a flag arg
- Add default config name

## PR Checks

<!-- All points must be addressed before merge -->

- [x] Release notes have been added for new features
- [x] Changes are covered by tests

## Testing

- Go Test
- Local execution

## Future Work

<!-- Optional -->
<!-- Add any future work plans that are not addressed by the PR but are raised by the PR -->

## Discussion Points

<!-- Optional -->
<!-- Points that need further discussion with the PR reviewers -->
